### PR TITLE
Created endpoints to get SleepLogs from following and followed people

### DIFF
--- a/app/controllers/api/v1/relationships_controller.rb
+++ b/app/controllers/api/v1/relationships_controller.rb
@@ -57,6 +57,20 @@ class Api::V1::RelationshipsController < ApplicationController
                                                               followers: followers) }, status: :ok
   end
 
+  # GET /api/v1/users/:user_id/relationships/following/sleep_logs
+  def sleep_logs_from_users_im_following
+    @sleep_logs = SleepLogService.logs_from_people_user_is_following(@user)
+
+    render json: { data: SleepLogBlueprint.render_as_json(@sleep_logs, view: :with_user_name) }, status: :ok
+  end
+
+  # GET /api/v1/users/:user_id/relationships/followers/sleep_logs
+  def sleep_logs_from_my_followers
+    @sleep_log = SleepLogService.logs_from_followers(@user)
+
+    render json: { data: SleepLogBlueprint.render_as_json(@sleep_log, view: :with_user_name) }, status: :ok
+  end
+
   private
 
   def set_user

--- a/app/controllers/api/v1/relationships_controller.rb
+++ b/app/controllers/api/v1/relationships_controller.rb
@@ -66,9 +66,9 @@ class Api::V1::RelationshipsController < ApplicationController
 
   # GET /api/v1/users/:user_id/relationships/followers/sleep_logs
   def sleep_logs_from_my_followers
-    @sleep_log = SleepLogService.logs_from_followers(@user)
+    @sleep_logs = SleepLogService.logs_from_followers(@user)
 
-    render json: { data: SleepLogBlueprint.render_as_json(@sleep_log, view: :with_user_name) }, status: :ok
+    render json: { data: SleepLogBlueprint.render_as_json(@sleep_logs, view: :with_user_name) }, status: :ok
   end
 
   private

--- a/app/services/sleep_log_service.rb
+++ b/app/services/sleep_log_service.rb
@@ -11,4 +11,19 @@ module SleepLogService
       last_sleep_log
     end
   end
+
+  def self.logs_from_people_user_is_following(user)
+    SleepLog.joins(user: :followed_relationships)
+            .where(followed_relationships: { source_id: user.id })
+            .where(sleep_logs: { created_at: 1.week.ago.all_week })
+            .order(duration: :desc)
+  end
+
+  def self.logs_from_followers(user)
+    # Different approach, but this approach does two queries instead of one.
+    SleepLog.where(user_id: user.followers.pluck(:id))
+            .where(sleep_logs: { created_at: 1.week.ago.all_week })
+            # .where('sleep_logs.created_at >= ?', 1.week.ago.beginning_of_day) # In case is the the previous 7 days
+            .order(duration: :desc)
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,9 @@ module GoodNightApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
 
+    # Set the beginning of the week to be Sunday
+    config.beginning_of_week = :sunday
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,10 @@ Rails.application.routes.draw do
           # Follow / Unfollow Actions
           post ':other_user_id', to: 'relationships#follow', on: :collection
           delete ':other_user_id', to: 'relationships#unfollow', on: :collection
+
+          # Sleep Logs
+          get 'following/sleep_logs', to: 'relationships#sleep_logs_from_users_im_following', on: :collection
+          get 'followers/sleep_logs', to: 'relationships#sleep_logs_from_my_followers', on: :collection
         end
 
         # Clock in endpoints

--- a/spec/routing/api/v1/relationship_routing_spec.rb
+++ b/spec/routing/api/v1/relationship_routing_spec.rb
@@ -27,5 +27,15 @@ describe Api::V1::RelationshipsController do
                                                                                         user_id: ':user_id',
                                                                                         other_user_id: ':other_user_id')
     end
+
+    it 'routes to /following/sleep_logs' do
+      expect(get: '/api/v1/users/:user_id/relationships/following/sleep_logs').to route_to('api/v1/relationships#sleep_logs_from_users_im_following',
+                                                                                           user_id: ':user_id')
+    end
+
+    it 'routes to /followers/sleep_logs' do
+      expect(get: '/api/v1/users/:user_id/relationships/followers/sleep_logs').to route_to('api/v1/relationships#sleep_logs_from_my_followers',
+                                                                                           user_id: ':user_id')
+    end
   end
 end

--- a/spec/services/sleep_log_service_spec.rb
+++ b/spec/services/sleep_log_service_spec.rb
@@ -4,42 +4,141 @@ require 'rails_helper'
 
 describe SleepLogService, type: :service do
   let!(:sleep_log_uuid) { SecureRandom.uuid }
-  let(:user) { build_stubbed(:user) }
+  let(:user) { create(:user, name: 'UserA') }
   let(:sleep_log) { build_stubbed(:sleep_log, user: user, uuid: sleep_log_uuid) }
   let(:full_sleep_log) { build_stubbed(:sleep_log, :eight_hours_sleep, user: user, uuid: sleep_log_uuid) }
 
-  context 'when the user has no SleepLogs' do
-    it 'returns a new SleepLog record' do
-      result = described_class.log_sleep_data(user)
+  describe '#log_sleep_data' do
+    context 'when the user has no SleepLogs' do
+      it 'returns a new SleepLog record' do
+        result = described_class.log_sleep_data(user)
 
-      expect(result).to be_new_record
-      expect(result.woke_up_at).to be_nil
-      expect(result.duration).to be_nil
+        expect(result).to be_new_record
+        expect(result.woke_up_at).to be_nil
+        expect(result.duration).to be_nil
+      end
+    end
+
+    context 'when the user has a SleepLog but without woke_up_at filled' do
+      it 'returns the last SleepLog with the woke_up_at attribute filled' do
+        expect(user).to receive_message_chain(:sleep_logs, :last).and_return(sleep_log)
+
+        result = described_class.log_sleep_data(user)
+
+        expect(result.uuid).to eq(sleep_log_uuid)
+        expect(result.woke_up_at).not_to be_nil
+      end
+    end
+
+    context 'when the user already has a SleepLog with woke_up_at filled' do
+      it 'returns a new SleepLog with the woke_up_at nil' do
+        uuid = SecureRandom.uuid
+        allow(user).to receive_message_chain(:sleep_logs, :last).and_return(full_sleep_log)
+        expect(user).to receive_message_chain(:sleep_logs, :new).and_return(SleepLog.new(uuid: uuid))
+
+        result = described_class.log_sleep_data(user)
+
+        expect(result.uuid).to eq(uuid)
+        expect(result.woke_up_at).to be_nil
+        expect(result.duration).to be_nil
+      end
     end
   end
 
-  context 'when the user has a SleepLog but without woke_up_at filled' do
-    it 'returns the last SleepLog with the woke_up_at attribute filled' do
-      expect(user).to receive_message_chain(:sleep_logs, :last).and_return(sleep_log)
+  context 'when testing logs from followers and people user is following' do
+    let(:user_b) { create(:user, name: 'UserB') }
+    let(:user_c) { create(:user, name: 'UserC') }
+    let(:user_d) { create(:user, name: 'UserD') }
+    let(:user_e) { create(:user, name: 'UserE') }
 
-      result = described_class.log_sleep_data(user)
+    before do
+      create(:relationship, source: user, target: user_b) # UserA => UserB*
+      create(:relationship, source: user, target: user_c) # UserA => UserC*
+      create(:relationship, source: user_b, target: user) # UserB => UserA
+      create(:relationship, source: user_b, target: user_d) # UserB => UserD
+      create(:relationship, source: user_d, target: user) # UserD => UserA
+      create(:relationship, source: user_d, target: user_c) # UserD => UserC
 
-      expect(result.uuid).to eq(sleep_log_uuid)
-      expect(result.woke_up_at).not_to be_nil
+      time_now = Time.zone.parse('2023-06-15T16:52:23')
+      Timecop.freeze(time_now) do
+        # UserA
+        create(:sleep_log, user: user, created_at: time_now - 2.hours, woke_up_at: time_now) # 2 hours
+        create(:sleep_log, user: user, created_at: 3.days.ago - 4.hours, woke_up_at: 3.days.ago) # 4 hours
+        create(:sleep_log, user: user, created_at: 10.days.ago - 6.5.hours, woke_up_at: 10.days.ago) # 6.5 hours
+        # UserB*
+        create(:sleep_log, user: user_b, created_at: time_now - 8.hours, woke_up_at: time_now) # 8 hours
+        create(:sleep_log, user: user_b, created_at: 7.days.ago - 4.hours, woke_up_at: 7.days.ago) # 4 hours
+        create(:sleep_log, user: user_b, created_at: 8.days.ago - 5.hours, woke_up_at: 8.days.ago) # 5 hours
+        create(:sleep_log, user: user_b, created_at: 10.days.ago - 10.hours, woke_up_at: 10.days.ago) # 10 hours
+        # UserC*
+        create(:sleep_log, user: user_c, created_at: time_now - 7.hours, woke_up_at: time_now) # 7 hours
+        create(:sleep_log, user: user_c, created_at: 7.days.ago - 3.hours, woke_up_at: 7.days.ago) # 3 hours
+        create(:sleep_log, user: user_c, created_at: 6.days.ago - 4.5.hours, woke_up_at: 6.days.ago) # 4.5 hours
+        create(:sleep_log, user: user_c, created_at: 9.days.ago - 9.5.hours, woke_up_at: 9.days.ago) # 9.5 hours
+        create(:sleep_log, user: user_c, created_at: 20.days.ago - 8.5.hours, woke_up_at: 20.days.ago) # 8.5 hours
+        # UserD
+        create(:sleep_log, user: user_d, created_at: time_now - 10.hours, woke_up_at: time_now) # 10 hours
+        create(:sleep_log, user: user_d, created_at: 4.days.ago - 6.hours, woke_up_at: 4.days.ago) # 6 hours
+        create(:sleep_log, user: user_d, created_at: 8.days.ago - 4.hours, woke_up_at: 8.days.ago) # 4 hours
+        create(:sleep_log, user: user_d, created_at: 10.days.ago - 9.hours, woke_up_at: 10.days.ago) # 9 hours
+      end
     end
-  end
 
-  context 'when the user already has a SleepLog with woke_up_at filled' do
-    it 'returns a new SleepLog with the woke_up_at nil' do
-      uuid = SecureRandom.uuid
-      allow(user).to receive_message_chain(:sleep_logs, :last).and_return(full_sleep_log)
-      expect(user).to receive_message_chain(:sleep_logs, :new).and_return(SleepLog.new(uuid: uuid))
+    describe '#logs_from_people_user_is_following' do
+      context 'when the user is not following anyone' do
+        it 'returns an empty array' do
+          result = described_class.logs_from_people_user_is_following(user_c)
 
-      result = described_class.log_sleep_data(user)
+          expect(result).to be_empty
+        end
+      end
 
-      expect(result.uuid).to eq(uuid)
-      expect(result.woke_up_at).to be_nil
-      expect(result.duration).to be_nil
+      context 'when the user is following some people' do
+        it 'returns an the expected data from the previous week (June 4th to June 10th)' do
+          result = described_class.logs_from_people_user_is_following(user)
+
+          expected_result = [
+            { duration: '10:00:00', user_id: user_b.id },
+            { duration: '09:30:00', user_id: user_c.id },
+            { duration: '05:00:00', user_id: user_b.id },
+            { duration: '04:30:00', user_id: user_c.id },
+            { duration: '04:00:00', user_id: user_b.id },
+            { duration: '03:00:00', user_id: user_c.id }
+          ]
+
+          mapped_data = result.map { |log| { duration: log.duration.strftime('%H:%M:%S'), user_id: log.user_id } }
+
+          expect(result.size).to eq(6)
+          expect(mapped_data).to eq(expected_result)
+        end
+      end
+    end
+
+    describe '#logs_from_followers' do
+      context 'when the user has no follower' do
+        it 'returns an empty array' do
+          result = described_class.logs_from_followers(user_e)
+
+          expect(result).to be_empty
+        end
+      end
+
+      context 'when the user has some followers' do
+        it 'returns an the expected data from the previous week (June 4th to June 10th)' do
+          result = described_class.logs_from_followers(user_c)
+
+          expected_result = [
+            { duration: '09:00:00', user_id: user_d.id },
+            { duration: '06:30:00', user_id: user.id },
+            { duration: '04:00:00', user_id: user_d.id }
+          ]
+
+          mapped_data = result.map { |log| { duration: log.duration.strftime('%H:%M:%S'), user_id: log.user_id } }
+
+          expect(result.size).to eq(3)
+          expect(mapped_data).to eq(expected_result)
+        end
+      end
     end
   end
 end

--- a/spec/services/sleep_log_service_spec.rb
+++ b/spec/services/sleep_log_service_spec.rb
@@ -94,7 +94,7 @@ describe SleepLogService, type: :service do
       end
 
       context 'when the user is following some people' do
-        it 'returns an the expected data from the previous week (June 4th to June 10th)' do
+        it 'returns an the expected data from the previous week (June 4th to June 11th)' do
           result = described_class.logs_from_people_user_is_following(user)
 
           expected_result = [
@@ -124,7 +124,7 @@ describe SleepLogService, type: :service do
       end
 
       context 'when the user has some followers' do
-        it 'returns an the expected data from the previous week (June 4th to June 10th)' do
+        it 'returns an the expected data from the previous week (June 4th to June 11th)' do
           result = described_class.logs_from_followers(user_c)
 
           expected_result = [


### PR DESCRIPTION
- Changed the start of the week day to Sunday

- Created endpoints related to User's data:
  - Get records of all users: 
    - GET `/api/v1/users`
  - Get record from a specific user: 
    - GET /api/v1/users/:id
    
- Created endpoints related to getting the SleepLogs for Followings/Followers users
  - Get SleepLogs from the previous week (June 4th to June 11th) from users the person is following: 
    - GET `/api/v1/users/:user_id/relationships/following/sleep_logs`
  - Get SleepLogs from the previous week (June 4th to June 11th) for the users that are followers of the person (followers logs): 
    - GET `/api/v1/users/:user_id/relationships/followers/sleep_logs`

- Created the tests for the developed features